### PR TITLE
Converted setup to python 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
 		<dependency>
 			<groupId>org.icatproject</groupId>
 			<artifactId>icat.utils</artifactId>
-			<version>4.16.0</version>
+			<version>4.16.1</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/scripts/setup
+++ b/src/main/scripts/setup
@@ -27,14 +27,14 @@ if arg == "INSTALL":
         ovfiles = [[prop_name, "WEB-INF/classes"]]
         if os.path.exists("logback.xml"): ovfiles.append(["logback.xml", "WEB-INF/classes"])
         actions.deploy(deploymentorder=80, files=ovfiles)
-    except Exception, e:
+    except Exception as e:
         abort(str(e))
                 
 if arg == "UNINSTALL":        
 
     try:
         uninstall()
-    except Exception, e:
+    except Exception as e:
         abort(str(e))       
     
             


### PR DESCRIPTION
This PR aims to allow the ICAT Lucene setup script to be run under Python 2 and Python 3.

Still need to:
- [ ] Test on Windows + Python 2
- [ ] Test on Windows + Python 3
- [ ] Test on Linux + Python 2
- [ ] Test on Linux + Python 3