### PR TITLE
Use python3 instead of python

### DIFF
--- a/src/main/scripts/setup
+++ b/src/main/scripts/setup
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from setup_utils import *
 import os
 import socket


### PR DESCRIPTION
Modern distros often don't have a `python` command, so use `python3` explicitly.