### PR TITLE
Configure Dependabot version updates for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates every week
+      interval: "weekly"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -35,7 +35,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Checkout icat-lucene
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run Build
         run: mvn install -Dmaven.install.skip -DskipTests

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -27,7 +27,7 @@ jobs:
           java-version: ${{ matrix.version }}
 
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.version }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -21,13 +21,13 @@ jobs:
 
     steps:
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@3f07048e3d294f56e9b90ac5ea2c6f74e9ad0f98 # v3.10.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.version }}
 
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -35,7 +35,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Checkout icat-lucene
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
       - name: Run Build
         run: mvn install -Dmaven.install.skip -DskipTests


### PR DESCRIPTION
Configures Dependabot to check and open new PRs when new action versions are released. Also addresses the warnings by GitHub Actions in the CI.