### PR TITLE
Use IcatSynonymAnalyzer to write Documents

### DIFF
--- a/src/main/java/org/icatproject/lucene/Lucene.java
+++ b/src/main/java/org/icatproject/lucene/Lucene.java
@@ -387,7 +387,7 @@ public class Lucene {
 
 	static final Logger logger = LoggerFactory.getLogger(Lucene.class);
 	private static final Marker fatal = MarkerFactory.getMarker("FATAL");
-	private static final IcatAnalyzer analyzer = new IcatAnalyzer();
+	private static final IcatSynonymAnalyzer analyzer = new IcatSynonymAnalyzer();
 
 	private final FacetsConfig facetsConfig = new FacetsConfig();
 

--- a/src/test/java/icat/lucene/TestLucene.java
+++ b/src/test/java/icat/lucene/TestLucene.java
@@ -28,6 +28,7 @@ import org.apache.lucene.facet.sortedset.SortedSetDocValuesFacetCounts;
 import org.apache.lucene.facet.sortedset.SortedSetDocValuesFacetField;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
@@ -117,6 +118,36 @@ public class TestLucene {
 
 		assertEquals(24, n);
 		assertEquals(" h hydrogen he helium li lithium beryllium be boron b neon ne ioniz ionis tof time of flight techniqu arp angl resolv photoemiss spectroscopi", newString);
+	}
+
+	/**
+	 * Test that IcatSynonymAnalyzer handles synonym injection within phrases
+	 */
+	@Test
+	public void testIcatSynonymAnalyzerPhrase() throws Exception {
+		Analyzer analyzer = new IcatSynonymAnalyzer();
+		StandardQueryParser parser = new StandardQueryParser();
+		StandardQueryConfigHandler qpConf = (StandardQueryConfigHandler) parser.getQueryConfigHandler();
+		qpConf.set(ConfigurationKeys.ANALYZER, analyzer);
+
+		Path tmpLuceneDir = Files.createTempDirectory("lucene");
+		FSDirectory datafileDirectory = FSDirectory.open(tmpLuceneDir.resolve("Datafile"));
+		IndexWriterConfig config = new IndexWriterConfig(analyzer);
+		config.setOpenMode(OpenMode.CREATE);
+		IndexWriter datafileWriter = new IndexWriter(datafileDirectory, config);
+		Document doc = new Document();
+		doc.add(new TextField("location", "/path/to/data/mr/file.txt", Store.YES));
+		datafileWriter.addDocument(doc);
+		datafileWriter.close();
+
+		Query query = parser.parse("location:\"/path/to/data/mr/file.txt\"", null);
+		IndexSearcher datafileSearcher = new IndexSearcher(DirectoryReader.open(datafileDirectory));
+		TopDocs topDocs = datafileSearcher.search(query, 1);
+
+		assertEquals("location:\"path ? data (mr molecular) replac file.txt\"", query.toString());
+		assertEquals(topDocs.totalHits.value, 1L);
+		Document document = datafileSearcher.doc(topDocs.scoreDocs[0].doc);
+		assertEquals("/path/to/data/mr/file.txt", document.get("location"));
 	}
 
 	/**


### PR DESCRIPTION
When indexing, we were using a non-synonym version of the analyzer, but when searching synonyms were being injected. When doing basic OR logic queries (e.g. `path to mr file`) this is OK. The search term gets `molecular replac` injected, which isn't present in the Document but this is OK as it's an OR query.

When doing an phrase query (the most common use case for this is to quote an exact filepath, which will remove the `/` characters easily) each word has to match in order. At this point, there is no longer a match for the injected terms.

By using `IcatSynonymAnalyzer` for both, we can ensure that the injected term appear in both the search query and in the indexed Document we match against.