### PR TITLE
Allow auto-commit to be disabled

### DIFF
--- a/src/main/java/org/icatproject/lucene/Lucene.java
+++ b/src/main/java/org/icatproject/lucene/Lucene.java
@@ -1041,7 +1041,7 @@ public class Lucene {
 				throw new Exception(luceneDirectory + " is not a directory");
 			}
 
-			commitSeconds = props.getPositiveInt("commitSeconds");
+			commitSeconds = props.getNonNegativeInt("commitSeconds");
 			luceneCommitMillis = commitSeconds * 1000;
 			luceneMaxShardSize = Math.min(props.getPositiveLong("maxShardSize"), Long.valueOf(Integer.MAX_VALUE - 128));
 			maxSearchTimeSeconds = props.has("maxSearchTimeSeconds") ? props.getPositiveLong("maxSearchTimeSeconds")
@@ -1072,8 +1072,10 @@ public class Lucene {
 	 * Starts a timer and schedules regular commits of the IndexWriter.
 	 */
 	private void initTimer() {
-		timer = new Timer("LuceneCommitTimer");
-		timer.schedule(new CommitTimerTask(), luceneCommitMillis, luceneCommitMillis);
+		if (luceneCommitMillis > 0) {
+			timer = new Timer("LuceneCommitTimer");
+			timer.schedule(new CommitTimerTask(), luceneCommitMillis, luceneCommitMillis);
+		}
 	}
 
 	class CommitTimerTask extends TimerTask {


### PR DESCRIPTION
Does not start a commit timer thread if `commitSeconds` is 0 in `run.properties`.