### PR TITLE
Expand location into location, location.exact, location.fileName

### DIFF
--- a/src/main/java/org/icatproject/lucene/DocumentMapping.java
+++ b/src/main/java/org/icatproject/lucene/DocumentMapping.java
@@ -1,15 +1,17 @@
 package org.icatproject.lucene;
 
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.core.KeywordAnalyzer;
+import org.apache.lucene.analysis.miscellaneous.PerFieldAnalyzerWrapper;
 import org.apache.lucene.queryparser.flexible.standard.StandardQueryParser;
 import org.apache.lucene.queryparser.flexible.standard.config.StandardQueryConfigHandler;
 import org.apache.lucene.queryparser.flexible.standard.config.StandardQueryConfigHandler.ConfigurationKeys;
+import org.icatproject.lucene.analyzers.IcatSeparatorAnalyzer;
+import org.icatproject.lucene.analyzers.IcatSynonymAnalyzer;
 
 public class DocumentMapping {
 
@@ -26,10 +28,10 @@ public class DocumentMapping {
 		 * @param parentName    Name of the parent entity.
 		 * @param joiningField  Field that joins the child to its parent.
 		 * @param cascadeDelete If the child is deleted, whether the parent onto which
-		 * 						it is nested should be deleted wholesale or just have
-		 * 						its fields pruned.
+		 *                      it is nested should be deleted wholesale or just have
+		 *                      its fields pruned.
 		 * @param fields        Fields that should be updated by this relationship where
-		 * 					    the field is the same on parent and child.
+		 *                      the field is the same on parent and child.
 		 */
 		public ParentRelationship(String parentName, String joiningField, boolean cascadeDelete, String... fields) {
 			this.parentName = parentName;
@@ -50,18 +52,63 @@ public class DocumentMapping {
 		}
 	}
 
-	private static Analyzer analyzer = new IcatSynonymAnalyzer();;
-
-	public static final Set<String> doubleFields = new HashSet<>();
-	public static final Set<String> longFields = new HashSet<>();
-	public static final Set<String> sortFields = new HashSet<>();
-	public static final Set<String> textFields = new HashSet<>();
-	public static final Set<String> indexedEntities = new HashSet<>();
-	public static final Map<String, ParentRelationship[]> relationships = new HashMap<>();
+	public static final Set<String> doubleFields = Set.of("numericValue", "numericValueSI", "rangeTop", "rangeTopSI",
+			"rangeBottom", "rangeBottomSI");
+	public static final Set<String> longFields = Set.of("date", "startDate", "endDate", "dateTimeValue",
+			"investigation.startDate", "fileSize", "fileCount", "datafile.id", "datafileFormat.id", "dataset.id",
+			"facility.id", "facilityCycle.id", "investigation.id", "instrument.id", "id", "sample.id",
+			"sample.investigation.id", "sample.type.id", "technique.id", "type.id", "user.id");
+	public static final Set<String> sortFields = Set.of("datafile.id", "datafileFormat.id", "dataset.id", "facility.id",
+			"facilityCycle.id", "investigation.id", "instrument.id", "id", "sample.id", "sample.investigation.id",
+			"technique.id", "type.id", "user.id", "date", "name", "stringValue", "dateTimeValue", "numericValue",
+			"numericValueSI", "fileSize", "fileCount");
+	public static final Set<String> textFields = Set.of("name", "visitId", "description", "dataset.name",
+			"investigation.name", "instrument.name", "instrument.fullName", "datafileFormat.name", "sample.name",
+			"sample.type.name", "technique.name", "technique.description", "technique.pid", "title", "summary",
+			"facility.name", "user.fullName", "type.name", "doi");
+	public static final Set<String> pathFields = Set.of("location");
+	public static final Set<String> indexedEntities = Set.of("Datafile", "Dataset", "Investigation",
+			"DatafileParameter", "DatasetParameter", "DatasetTechnique", "InstrumentScientist",
+			"InvestigationFacilityCycle", "InvestigationInstrument", "InvestigationParameter", "InvestigationUser",
+			"Sample", "SampleParameter");
+	public static final Map<String, ParentRelationship[]> relationships = Map.ofEntries(
+			Map.entry("Instrument", new ParentRelationship[] {
+					new ParentRelationship("InvestigationInstrument", "instrument.id", true,
+							"instrument.name", "instrument.fullName") }),
+			Map.entry("User", new ParentRelationship[] {
+					new ParentRelationship("InvestigationUser", "user.id", true, "user.name", "user.fullName"),
+					new ParentRelationship("InstrumentScientist", "user.id", true, "user.name", "user.fullName") }),
+			Map.entry("Sample", new ParentRelationship[] {
+					new ParentRelationship("Dataset", "sample.id", false, "sample.name", "sample.investigation.id"),
+					new ParentRelationship("Datafile", "sample.id", false, "sample.name", "sample.investigation.id") }),
+			Map.entry("SampleType", new ParentRelationship[] {
+					new ParentRelationship("Sample", "type.id", true, "type.name"),
+					new ParentRelationship("Dataset", "sample.type.id", false, "sample.type.name"),
+					new ParentRelationship("Datafile", "sample.type.id", false, "sample.type.name") }),
+			Map.entry("InvestigationType", new ParentRelationship[] {
+					new ParentRelationship("Investigation", "type.id", true, "type.name") }),
+			Map.entry("DatasetType", new ParentRelationship[] {
+					new ParentRelationship("Dataset", "type.id", true, "type.name") }),
+			Map.entry("DatafileFormat", new ParentRelationship[] {
+					new ParentRelationship("Datafile", "datafileFormat.id", false, "datafileFormat.name") }),
+			Map.entry("Facility", new ParentRelationship[] {
+					new ParentRelationship("Investigation", "facility.id", true, "facility.name") }),
+			Map.entry("ParameterType", new ParentRelationship[] {
+					new ParentRelationship("DatafileParameter", "type.id", true, "type.name", "type.units"),
+					new ParentRelationship("DatasetParameter", "type.id", true, "type.name", "type.units"),
+					new ParentRelationship("InvestigationParameter", "type.id", true, "type.name", "type.units"),
+					new ParentRelationship("SampleParameter", "type.id", true, "type.name", "type.units") }),
+			Map.entry("Technique", new ParentRelationship[] {
+					new ParentRelationship("DatasetTechnique", "technique.id", true,
+							"technique.name", "technique.description", "technique.pid") }),
+			Map.entry("Investigation", new ParentRelationship[] {
+					new ParentRelationship("Dataset", "investigation.id", true, "visitId"),
+					new ParentRelationship("Datafile", "investigation.id", true, "visitId") }),
+			Map.entry("Dataset", new ParentRelationship[] { new ParentRelationship("Datafile", "dataset.id", true) }));
 
 	public static final StandardQueryParser genericParser = buildParser();
 	public static final StandardQueryParser datafileParser = buildParser("name", "description", "location",
-			"datafileFormat.name", "visitId", "sample.name", "sample.type.name", "doi");
+			"location.fileName", "datafileFormat.name", "visitId", "sample.name", "sample.type.name", "doi");
 	public static final StandardQueryParser datasetParser = buildParser("name", "description", "sample.name",
 			"sample.type.name", "type.name", "visitId", "doi");
 	public static final StandardQueryParser investigationParser = buildParser("name", "visitId", "title", "summary",
@@ -69,78 +116,29 @@ public class DocumentMapping {
 	public static final StandardQueryParser sampleParser = buildParser("sample.name", "sample.type.name");
 
 	static {
-		doubleFields.addAll(Arrays.asList("numericValue", "numericValueSI", "rangeTop", "rangeTopSI", "rangeBottom",
-				"rangeBottomSI"));
-		longFields.addAll(
-				Arrays.asList("date", "startDate", "endDate", "dateTimeValue", "investigation.startDate", "fileSize",
-						"fileCount", "datafile.id", "datafileFormat.id", "dataset.id", "facility.id",
-						"facilityCycle.id", "investigation.id", "instrument.id", "id", "sample.id",
-						"sample.investigation.id", "sample.type.id", "technique.id", "type.id", "user.id"));
-		sortFields.addAll(
-				Arrays.asList("datafile.id", "datafileFormat.id", "dataset.id", "facility.id", "facilityCycle.id",
-						"investigation.id", "instrument.id", "id", "sample.id", "sample.investigation.id",
-						"technique.id", "type.id", "user.id", "date", "name", "stringValue", "dateTimeValue",
-						"numericValue", "numericValueSI", "fileSize", "fileCount"));
-		textFields.addAll(Arrays.asList("name", "visitId", "description", "location", "dataset.name",
-				"investigation.name", "instrument.name", "instrument.fullName", "datafileFormat.name", "sample.name",
-				"sample.type.name", "technique.name", "technique.description", "technique.pid", "title", "summary",
-				"facility.name", "user.fullName", "type.name", "doi"));
-
-		indexedEntities.addAll(Arrays.asList("Datafile", "Dataset", "Investigation", "DatafileParameter",
-				"DatasetParameter", "DatasetTechnique", "InstrumentScientist", "InvestigationFacilityCycle",
-				"InvestigationInstrument", "InvestigationParameter", "InvestigationUser", "Sample", "SampleParameter"));
-
-		relationships.put("Instrument", new ParentRelationship[] {
-				new ParentRelationship("InvestigationInstrument", "instrument.id", true, "instrument.name",
-						"instrument.fullName") });
-		relationships.put("User", new ParentRelationship[] {
-				new ParentRelationship("InvestigationUser", "user.id", true, "user.name", "user.fullName"),
-				new ParentRelationship("InstrumentScientist", "user.id", true, "user.name", "user.fullName") });
-		relationships.put("Sample", new ParentRelationship[] {
-				new ParentRelationship("Dataset", "sample.id", false, "sample.name", "sample.investigation.id"),
-				new ParentRelationship("Datafile", "sample.id", false, "sample.name", "sample.investigation.id") });
-		relationships.put("SampleType", new ParentRelationship[] {
-				new ParentRelationship("Sample", "type.id", true, "type.name"),
-				new ParentRelationship("Dataset", "sample.type.id", false, "sample.type.name"),
-				new ParentRelationship("Datafile", "sample.type.id", false, "sample.type.name") });
-		relationships.put("InvestigationType",
-				new ParentRelationship[] { new ParentRelationship("Investigation", "type.id", true, "type.name") });
-		relationships.put("DatasetType",
-				new ParentRelationship[] { new ParentRelationship("Dataset", "type.id", true, "type.name") });
-		relationships.put("DatafileFormat",
-				new ParentRelationship[] {
-						new ParentRelationship("Datafile", "datafileFormat.id", false, "datafileFormat.name") });
-		relationships.put("Facility",
-				new ParentRelationship[] { new ParentRelationship("Investigation", "facility.id", true, "facility.name") });
-		relationships.put("ParameterType",
-				new ParentRelationship[] {
-						new ParentRelationship("DatafileParameter", "type.id", true, "type.name", "type.units"),
-						new ParentRelationship("DatasetParameter", "type.id", true,"type.name", "type.units"),
-						new ParentRelationship("InvestigationParameter", "type.id", true, "type.name", "type.units"),
-						new ParentRelationship("SampleParameter", "type.id", true, "type.name", "type.units") });
-		relationships.put("Technique",
-				new ParentRelationship[] { new ParentRelationship("DatasetTechnique", "technique.id", true,"technique.name",
-						"technique.description", "technique.pid") });
-
-		ParentRelationship investigationDatasetRelationship = new ParentRelationship("Dataset", "investigation.id",
-				true, "visitId");
+		ParentRelationship investigationDatasetRelationship = relationships.get("Investigation")[0];
 		investigationDatasetRelationship.mapField("investigation.name", "name");
 		investigationDatasetRelationship.mapField("investigation.title", "title");
 		investigationDatasetRelationship.mapField("investigation.startDate", "startDate");
-		ParentRelationship investigationDatafileRelationship = new ParentRelationship("Datafile", "investigation.id",
-				true,"visitId");
-		investigationDatafileRelationship.mapField("investigation.name", "name");
-		relationships.put("Investigation", new ParentRelationship[] {investigationDatasetRelationship, investigationDatafileRelationship });
 
-		ParentRelationship datasetDatafileRelationship = new ParentRelationship("Datafile", "dataset.id", true);
+		ParentRelationship investigationDatafileRelationship = relationships.get("Investigation")[1];
+		investigationDatafileRelationship.mapField("investigation.name", "name");
+
+		ParentRelationship datasetDatafileRelationship = relationships.get("Dataset")[0];
 		datasetDatafileRelationship.mapField("dataset.name", "name");
-		relationships.put("Dataset", new ParentRelationship[] { datasetDatafileRelationship });
 	}
 
 	private static StandardQueryParser buildParser(String... defaultFields) {
-		StandardQueryParser parser = new StandardQueryParser();
+		HashMap<String, Analyzer> analyzerMap = new HashMap<>();
+		for (String pathField : pathFields) {
+			analyzerMap.put(pathField, new IcatSeparatorAnalyzer("/"));
+			analyzerMap.put(pathField + ".exact", new KeywordAnalyzer());
+			analyzerMap.put(pathField + ".fileName", new IcatSeparatorAnalyzer("."));
+		}
+		PerFieldAnalyzerWrapper analyzerWrapper = new PerFieldAnalyzerWrapper(new IcatSynonymAnalyzer(), analyzerMap);
+		StandardQueryParser parser = new StandardQueryParser(analyzerWrapper);
+
 		StandardQueryConfigHandler qpConf = (StandardQueryConfigHandler) parser.getQueryConfigHandler();
-		qpConf.set(ConfigurationKeys.ANALYZER, analyzer);
 		qpConf.set(ConfigurationKeys.ALLOW_LEADING_WILDCARD, true);
 		if (defaultFields.length > 0) {
 			qpConf.set(ConfigurationKeys.MULTI_FIELDS, defaultFields);

--- a/src/main/java/org/icatproject/lucene/DocumentMapping.java
+++ b/src/main/java/org/icatproject/lucene/DocumentMapping.java
@@ -30,25 +30,17 @@ public class DocumentMapping {
 		 * @param cascadeDelete If the child is deleted, whether the parent onto which
 		 *                      it is nested should be deleted wholesale or just have
 		 *                      its fields pruned.
-		 * @param fields        Fields that should be updated by this relationship where
-		 *                      the field is the same on parent and child.
+		 * @param fieldMapping  Fields that should be updated by this relationship. The
+		 * 						key and value will be the same for most fields, but for
+		 * 						some they will differ to allow fields to be flattened
+		 * 						across entities (e.g. dataset.name: name).
 		 */
-		public ParentRelationship(String parentName, String joiningField, boolean cascadeDelete, String... fields) {
+		public ParentRelationship(String parentName, String joiningField, boolean cascadeDelete,
+				Map<String, String> fieldMapping) {
 			this.parentName = parentName;
 			this.joiningField = joiningField;
 			this.cascadeDelete = cascadeDelete;
-			fieldMapping = new HashMap<>();
-			for (String field : fields) {
-				fieldMapping.put(field, field);
-			}
-		}
-
-		/**
-		 * @param parentField Name on the parent, such as "dataset.name"
-		 * @param childField  Name on the child, such as "name"
-		 */
-		public void mapField(String parentField, String childField) {
-			fieldMapping.put(parentField, childField);
+			this.fieldMapping = fieldMapping;
 		}
 	}
 
@@ -74,37 +66,54 @@ public class DocumentMapping {
 	public static final Map<String, ParentRelationship[]> relationships = Map.ofEntries(
 			Map.entry("Instrument", new ParentRelationship[] {
 					new ParentRelationship("InvestigationInstrument", "instrument.id", true,
-							"instrument.name", "instrument.fullName") }),
+							Map.of("instrument.name", "instrument.name", "instrument.fullName", "instrument.fullName")) }),
 			Map.entry("User", new ParentRelationship[] {
-					new ParentRelationship("InvestigationUser", "user.id", true, "user.name", "user.fullName"),
-					new ParentRelationship("InstrumentScientist", "user.id", true, "user.name", "user.fullName") }),
+					new ParentRelationship("InvestigationUser", "user.id", true,
+							Map.of("user.name", "user.name", "user.fullName", "user.fullName")),
+					new ParentRelationship("InstrumentScientist", "user.id", true,
+							Map.of("user.name", "user.name", "user.fullName", "user.fullName")) }),
 			Map.entry("Sample", new ParentRelationship[] {
-					new ParentRelationship("Dataset", "sample.id", false, "sample.name", "sample.investigation.id"),
-					new ParentRelationship("Datafile", "sample.id", false, "sample.name", "sample.investigation.id") }),
+					new ParentRelationship("Dataset", "sample.id", false,
+							Map.of("sample.name", "sample.name", "sample.investigation.id", "sample.investigation.id")),
+					new ParentRelationship("Datafile", "sample.id", false,
+							Map.of("sample.name", "sample.name", "sample.investigation.id", "sample.investigation.id")) }),
 			Map.entry("SampleType", new ParentRelationship[] {
-					new ParentRelationship("Sample", "type.id", true, "type.name"),
-					new ParentRelationship("Dataset", "sample.type.id", false, "sample.type.name"),
-					new ParentRelationship("Datafile", "sample.type.id", false, "sample.type.name") }),
+					new ParentRelationship("Sample", "type.id", true, Map.of("type.name", "type.name")),
+					new ParentRelationship("Dataset", "sample.type.id", false,
+							Map.of("sample.type.name", "sample.type.name")),
+					new ParentRelationship("Datafile", "sample.type.id", false,
+							Map.of("sample.type.name", "sample.type.name")) }),
 			Map.entry("InvestigationType", new ParentRelationship[] {
-					new ParentRelationship("Investigation", "type.id", true, "type.name") }),
+					new ParentRelationship("Investigation", "type.id", true, Map.of("type.name", "type.name")) }),
 			Map.entry("DatasetType", new ParentRelationship[] {
-					new ParentRelationship("Dataset", "type.id", true, "type.name") }),
+					new ParentRelationship("Dataset", "type.id", true, Map.of("type.name", "type.name")) }),
 			Map.entry("DatafileFormat", new ParentRelationship[] {
-					new ParentRelationship("Datafile", "datafileFormat.id", false, "datafileFormat.name") }),
+					new ParentRelationship("Datafile", "datafileFormat.id", false,
+							Map.of("datafileFormat.name", "datafileFormat.name")) }),
 			Map.entry("Facility", new ParentRelationship[] {
-					new ParentRelationship("Investigation", "facility.id", true, "facility.name") }),
+					new ParentRelationship("Investigation", "facility.id", true,
+							Map.of("facility.name", "facility.name")) }),
 			Map.entry("ParameterType", new ParentRelationship[] {
-					new ParentRelationship("DatafileParameter", "type.id", true, "type.name", "type.units"),
-					new ParentRelationship("DatasetParameter", "type.id", true, "type.name", "type.units"),
-					new ParentRelationship("InvestigationParameter", "type.id", true, "type.name", "type.units"),
-					new ParentRelationship("SampleParameter", "type.id", true, "type.name", "type.units") }),
+					new ParentRelationship("DatafileParameter", "type.id", true,
+							Map.of("type.name", "type.name", "type.units", "type.units")),
+					new ParentRelationship("DatasetParameter", "type.id", true,
+							Map.of("type.name", "type.name", "type.units", "type.units")),
+					new ParentRelationship("InvestigationParameter", "type.id", true,
+							Map.of("type.name", "type.name", "type.units", "type.units")),
+					new ParentRelationship("SampleParameter", "type.id", true,
+							Map.of("type.name", "type.name", "type.units", "type.units")) }),
 			Map.entry("Technique", new ParentRelationship[] {
 					new ParentRelationship("DatasetTechnique", "technique.id", true,
-							"technique.name", "technique.description", "technique.pid") }),
+							Map.of("technique.name", "technique.name", "technique.description", "technique.description",
+									"technique.pid", "technique.pid")) }),
 			Map.entry("Investigation", new ParentRelationship[] {
-					new ParentRelationship("Dataset", "investigation.id", true, "visitId"),
-					new ParentRelationship("Datafile", "investigation.id", true, "visitId") }),
-			Map.entry("Dataset", new ParentRelationship[] { new ParentRelationship("Datafile", "dataset.id", true) }));
+					new ParentRelationship("Dataset", "investigation.id", true,
+							Map.of("visitId", "visitId", "investigation.name", "name", "investigation.title", "title",
+									"investigation.startDate", "startDate")),
+					new ParentRelationship("Datafile", "investigation.id", true,
+							Map.of("visitId", "visitId", "investigation.name", "name")) }),
+			Map.entry("Dataset", new ParentRelationship[] {
+					new ParentRelationship("Datafile", "dataset.id", true, Map.of("dataset.name", "name")) }));
 
 	public static final StandardQueryParser genericParser = buildParser();
 	public static final StandardQueryParser datafileParser = buildParser("name", "description", "location",
@@ -114,19 +123,6 @@ public class DocumentMapping {
 	public static final StandardQueryParser investigationParser = buildParser("name", "visitId", "title", "summary",
 			"facility.name", "type.name", "doi");
 	public static final StandardQueryParser sampleParser = buildParser("sample.name", "sample.type.name");
-
-	static {
-		ParentRelationship investigationDatasetRelationship = relationships.get("Investigation")[0];
-		investigationDatasetRelationship.mapField("investigation.name", "name");
-		investigationDatasetRelationship.mapField("investigation.title", "title");
-		investigationDatasetRelationship.mapField("investigation.startDate", "startDate");
-
-		ParentRelationship investigationDatafileRelationship = relationships.get("Investigation")[1];
-		investigationDatafileRelationship.mapField("investigation.name", "name");
-
-		ParentRelationship datasetDatafileRelationship = relationships.get("Dataset")[0];
-		datasetDatafileRelationship.mapField("dataset.name", "name");
-	}
 
 	private static StandardQueryParser buildParser(String... defaultFields) {
 		HashMap<String, Analyzer> analyzerMap = new HashMap<>();

--- a/src/main/java/org/icatproject/lucene/Field.java
+++ b/src/main/java/org/icatproject/lucene/Field.java
@@ -22,7 +22,7 @@ import org.apache.lucene.util.NumericUtils;
  * Wrapper for the name, value and type (String/Text, long, double) of a field
  * to be added to a Lucene Document.
  */
-class Field {
+public class Field {
 
     private abstract class InnerField {
 
@@ -58,6 +58,13 @@ class Field {
 
             if (DocumentMapping.textFields.contains(name)) {
                 document.add(new TextField(name, value, Store.YES));
+            } else if (DocumentMapping.pathFields.contains(name)) {
+                document.add(new TextField(name, value, Store.YES));
+                document.add(new TextField(name + ".exact", value, Store.NO));
+                int index = value.lastIndexOf("/");
+                if (index != -1) {
+                    document.add(new TextField(name + ".fileName", value.substring(index + 1), Store.NO));
+                }
             } else {
                 document.add(new StringField(name, value, Store.YES));
             }
@@ -137,6 +144,19 @@ class Field {
         } else {
             innerField = new InnerStringField(object.getString(key));
         }
+    }
+
+    /**
+     * Creates a wrapper for a String Field.
+     * 
+     * @param name        Name of the field to be used on the Document
+     * @param value       String value of the field
+     * @param facetFields List of String field names which should be stored as a facetable keyword
+     */
+    public Field(String name, String value, List<String> facetFields) {
+        this.name = name;
+        facetable = facetFields.contains(name);
+        innerField = new InnerStringField(value);
     }
 
     /**

--- a/src/main/java/org/icatproject/lucene/analyzers/IcatAnalyzer.java
+++ b/src/main/java/org/icatproject/lucene/analyzers/IcatAnalyzer.java
@@ -1,4 +1,4 @@
-package org.icatproject.lucene;
+package org.icatproject.lucene.analyzers;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/org/icatproject/lucene/analyzers/IcatSeparatorAnalyzer.java
+++ b/src/main/java/org/icatproject/lucene/analyzers/IcatSeparatorAnalyzer.java
@@ -1,0 +1,27 @@
+package org.icatproject.lucene.analyzers;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.core.LowerCaseFilter;
+import org.apache.lucene.analysis.util.CharTokenizer;
+
+public class IcatSeparatorAnalyzer extends Analyzer {
+
+    private int code;
+
+    public IcatSeparatorAnalyzer(String separator) {
+        code = separator.codePointAt(0);
+    }
+
+    private boolean separatorCharPredicate(int x) {
+        return x == code;
+    }
+
+    @Override
+    protected TokenStreamComponents createComponents(String fieldName) {
+        Tokenizer source = CharTokenizer.fromSeparatorCharPredicate(this::separatorCharPredicate);
+        TokenStream sink = new LowerCaseFilter(source);
+        return new TokenStreamComponents(source, sink);
+    }
+}

--- a/src/main/java/org/icatproject/lucene/analyzers/IcatSynonymAnalyzer.java
+++ b/src/main/java/org/icatproject/lucene/analyzers/IcatSynonymAnalyzer.java
@@ -1,4 +1,4 @@
-package org.icatproject.lucene;
+package org.icatproject.lucene.analyzers;
 
 import java.io.BufferedReader;
 import java.io.InputStream;


### PR DESCRIPTION
- Whitespace changes
- Replace `static {}` block with initialising using `Set.of` and `Map.ofEntries`
- Create new analyzer class which just performs separation (e.g. by `/` or `.`) and casting to lowercase
- Replace current `location` field (parsed as text using IcatSynonymAnalyzer) with `location` (separated by `/`) `location.fileName` (only the last part of the path separated by `.`) and `location.exact` (hierarchical tokens generated by [PathHierarchyTokenizer](https://lucene.apache.org/core/8_11_2/analyzers-common/org/apache/lucene/analysis/path/PathHierarchyTokenizer.html)
- On search, use the appropriate analyzers for these new fields (for `location.exact` use a keyword analyzer to get the [recommended behaviour](https://lucene.apache.org/core/8_11_2/analyzers-common/org/apache/lucene/analysis/path/PathHierarchyTokenizer.html)
- Some changes to visibility and new `Field` constructor for ease of use with tests
- Do not lowercase wildcard queries against the `location.exact` field as it is case sensitive (intended to be similar to `ls`, and allow discrimination between case unlike most fields which are insensitive)
- Automatically escape all `/` characters in paths, to reduce the burden on users
  - As a side effect, this will prevent use of regex syntax in the query

Closes #61 