### PR TITLE
Replace Sample index/fields with InvestigationSample index/fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>org.icatproject</groupId>
 	<artifactId>icat.lucene</artifactId>
-	<version>4.0.1-SNAPSHOT</version>
+	<version>5.0.0-SNAPSHOT</version>
 	<packaging>war</packaging>
 	<name>ICAT Lucene</name>
 

--- a/src/main/java/org/icatproject/lucene/DocumentMapping.java
+++ b/src/main/java/org/icatproject/lucene/DocumentMapping.java
@@ -48,12 +48,12 @@ public class DocumentMapping {
 			"rangeBottom", "rangeBottomSI");
 	public static final Set<String> longFields = Set.of("date", "startDate", "endDate", "dateTimeValue",
 			"investigation.startDate", "fileSize", "fileCount", "datafile.id", "datafileFormat.id", "dataset.id",
-			"facility.id", "facilityCycle.id", "investigation.id", "instrument.id", "id", "sample.id",
-			"sample.investigation.id", "sample.type.id", "technique.id", "type.id", "user.id");
+			"facility.id", "facilityCycle.id", "investigation.id", "instrument.id", "id", "sample.id", "sample.type.id",
+			"technique.id", "type.id", "user.id");
 	public static final Set<String> sortFields = Set.of("datafile.id", "datafileFormat.id", "dataset.id", "facility.id",
-			"facilityCycle.id", "investigation.id", "instrument.id", "id", "sample.id", "sample.investigation.id",
-			"technique.id", "type.id", "user.id", "date", "name", "stringValue", "dateTimeValue", "numericValue",
-			"numericValueSI", "fileSize", "fileCount");
+			"facilityCycle.id", "investigation.id", "instrument.id", "id", "sample.id", "technique.id", "type.id",
+			"user.id", "date", "name", "stringValue", "dateTimeValue", "numericValue", "numericValueSI", "fileSize",
+			"fileCount");
 	public static final Set<String> textFields = Set.of("name", "visitId", "description", "dataset.name",
 			"investigation.name", "instrument.name", "instrument.fullName", "datafileFormat.name", "sample.name",
 			"sample.type.name", "technique.name", "technique.description", "technique.pid", "title", "summary",
@@ -62,7 +62,7 @@ public class DocumentMapping {
 	public static final Set<String> indexedEntities = Set.of("Datafile", "Dataset", "Investigation",
 			"DatafileParameter", "DatasetParameter", "DatasetTechnique", "InstrumentScientist",
 			"InvestigationFacilityCycle", "InvestigationInstrument", "InvestigationParameter", "InvestigationUser",
-			"Sample", "SampleParameter");
+			"InvestigationSample", "SampleParameter");
 	public static final Map<String, ParentRelationship[]> relationships = Map.ofEntries(
 			Map.entry("Instrument", new ParentRelationship[] {
 					new ParentRelationship("InvestigationInstrument", "instrument.id", true,
@@ -73,10 +73,12 @@ public class DocumentMapping {
 					new ParentRelationship("InstrumentScientist", "user.id", true,
 							Map.of("user.name", "user.name", "user.fullName", "user.fullName")) }),
 			Map.entry("Sample", new ParentRelationship[] {
+					new ParentRelationship("InvestigationSample", "sample.id", false,
+							Map.of("sample.name", "sample.name")),
 					new ParentRelationship("Dataset", "sample.id", false,
-							Map.of("sample.name", "sample.name", "sample.investigation.id", "sample.investigation.id")),
+							Map.of("sample.name", "sample.name")),
 					new ParentRelationship("Datafile", "sample.id", false,
-							Map.of("sample.name", "sample.name", "sample.investigation.id", "sample.investigation.id")) }),
+							Map.of("sample.name", "sample.name")) }),
 			Map.entry("SampleType", new ParentRelationship[] {
 					new ParentRelationship("Sample", "type.id", true, Map.of("type.name", "type.name")),
 					new ParentRelationship("Dataset", "sample.type.id", false,

--- a/src/main/java/org/icatproject/lucene/SearchBucket.java
+++ b/src/main/java/org/icatproject/lucene/SearchBucket.java
@@ -288,10 +288,10 @@ public class SearchBucket {
             Query lowercasedQuery = lowercaseWildcardQueries(parsedQuery);
             textBuilder.add(lowercasedQuery, Occur.SHOULD);
 
-            IndexSearcher sampleSearcher = lucene.getSearcher(searcherMap, "Sample");
+            IndexSearcher sampleSearcher = lucene.getSearcher(searcherMap, "InvestigationSample");
             parsedQuery = DocumentMapping.sampleParser.parse(text, null);
             lowercasedQuery = lowercaseWildcardQueries(parsedQuery);
-            Query joinedSampleQuery = JoinUtil.createJoinQuery("sample.investigation.id", false, "id", Long.class,
+            Query joinedSampleQuery = JoinUtil.createJoinQuery("investigation.id", false, "id", Long.class,
                     lowercasedQuery, sampleSearcher, ScoreMode.Avg);
             textBuilder.add(joinedSampleQuery, Occur.SHOULD);
             luceneQuery.add(textBuilder.build(), Occur.MUST);
@@ -399,7 +399,7 @@ public class SearchBucket {
                     IndexSearcher nestedSearcher = lucene.getSearcher(searcherMap, filterTarget);
                     Query nestedQuery;
                     if (filterTarget.equals("sample") && target.equals("investigation")) {
-                        nestedQuery = JoinUtil.createJoinQuery("sample.investigation.id", false, "id", Long.class,
+                        nestedQuery = JoinUtil.createJoinQuery("investigation.id", false, "id", Long.class,
                                 dimensionQuery, nestedSearcher, ScoreMode.None);
                     } else if (filterTarget.toLowerCase().equals("investigationinstrument") && !target.equals("investigation")) {
                         nestedQuery = JoinUtil.createJoinQuery("investigation.id", false, "investigation.id", Long.class, dimensionQuery,
@@ -463,8 +463,8 @@ public class SearchBucket {
                     } else if (fld.equals("sampleparameter") && target.equals("investigation")) {
                         Query sampleQuery = JoinUtil.createJoinQuery("sample.id", false, "sample.id", Long.class,
                                 nestedBoolBuilder.build(), nestedSearcher, ScoreMode.None);
-                        return JoinUtil.createJoinQuery("sample.investigation.id", false, "id", Long.class, sampleQuery,
-                                lucene.getSearcher(searcherMap, "sample"), ScoreMode.None);
+                        return JoinUtil.createJoinQuery("investigation.id", false, "id", Long.class, sampleQuery,
+                                lucene.getSearcher(searcherMap, "InvestigationSample"), ScoreMode.None);
                     } else {
                         return JoinUtil.createJoinQuery(target + ".id", false, "id", Long.class,
                                 nestedBoolBuilder.build(), nestedSearcher, ScoreMode.None);


### PR DESCRIPTION
To support https://github.com/icatproject/icat.server/pull/294, the relevant entity to index is now InvestigationSample rather than Sample (as the former holds the investigation/sample ids required for joining across indices at search time).

As a secondary consequence, when flattening a Sample onto a Dataset, we no longer have to disambiguate between the sample.investigation.id (coming from the Sample->Investigation relationship) and the investigation.id (coming from the Dataset->Investigation relationship). There is no direct Sample->Investigation relationship anymore, so we can remove the former.